### PR TITLE
1.2.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        ruby: [2.5.9, 2.6.9, 2.7.5, 3.0.3, 3.1.0-preview1]
+        ruby: [2.7.6, 3.0.4, 3.1.2, 3.2.0-preview2]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 Nothing at the moment.
 
+## [1.2.0] - 2022-10-31
+
+Mainly some improvements to make test failures more resilient and improve the formatting when there are issues.
+
+- Don't consider binstubs project files when colorizing the stacktrace.
+- Switch debugging from Pry to debug
+- Ensure overly-long exception messages are truncated to reduce excessive scrolling
+- Make backtrace display smarter about how many lines to display
+- Fix bug that was incorrectly deleting the bin directory
+- Prepare for better handling of "stack level too deep" traces
+
 ## [1.1.0] - 2021-12-09
 
 The biggest update is that the slow thresholds are now configurable.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,32 +10,34 @@ GEM
     ast (2.4.2)
     awesome_print (1.9.2)
     coderay (1.1.3)
-    dead_end (3.0.2)
+    dead_end (4.0.0)
     docile (1.4.0)
+    json (2.6.2)
     method_source (1.0.0)
-    minitest (5.14.4)
-    parallel (1.21.0)
-    parser (3.0.2.0)
+    minitest (5.16.3)
+    parallel (1.22.1)
+    parser (3.1.2.1)
       ast (~> 2.4.1)
     pry (0.14.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
-    rainbow (3.0.0)
+    rainbow (3.1.1)
     rake (12.3.3)
-    regexp_parser (2.1.1)
+    regexp_parser (2.5.0)
     rexml (3.2.5)
-    rubocop (1.22.3)
+    rubocop (1.36.0)
+      json (~> 2.3)
       parallel (~> 1.10)
-      parser (>= 3.0.0.0)
+      parser (>= 3.1.2.1)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.8, < 3.0)
-      rexml
-      rubocop-ast (>= 1.12.0, < 2.0)
+      rexml (>= 3.2.5, < 4.0)
+      rubocop-ast (>= 1.20.1, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 3.0)
-    rubocop-ast (1.13.0)
-      parser (>= 3.0.1.1)
-    rubocop-minitest (0.15.2)
+    rubocop-ast (1.21.0)
+      parser (>= 3.1.1.0)
+    rubocop-minitest (0.22.1)
       rubocop (>= 0.90, < 2.0)
     rubocop-rake (0.6.0)
       rubocop (~> 1.0)
@@ -45,11 +47,11 @@ GEM
       simplecov-html (~> 0.11)
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.12.3)
-    simplecov_json_formatter (0.1.3)
-    unicode-display_width (2.1.0)
+    simplecov_json_formatter (0.1.4)
+    unicode-display_width (2.3.0)
 
 PLATFORMS
-  ruby
+  arm64-darwin-21
 
 DEPENDENCIES
   awesome_print
@@ -64,4 +66,4 @@ DEPENDENCIES
   simplecov
 
 BUNDLED WITH
-   2.2.30
+   2.3.22

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,21 +9,24 @@ GEM
   specs:
     ast (2.4.2)
     awesome_print (1.9.2)
-    coderay (1.1.3)
     dead_end (4.0.0)
+    debug (1.6.2)
+      irb (>= 1.3.6)
+      reline (>= 0.3.1)
     docile (1.4.0)
+    io-console (0.5.11)
+    irb (1.4.1)
+      reline (>= 0.3.0)
     json (2.6.2)
-    method_source (1.0.0)
     minitest (5.16.3)
     parallel (1.22.1)
     parser (3.1.2.1)
       ast (~> 2.4.1)
-    pry (0.14.1)
-      coderay (~> 1.1)
-      method_source (~> 1.0)
     rainbow (3.1.1)
     rake (12.3.3)
     regexp_parser (2.5.0)
+    reline (0.3.1)
+      io-console (~> 0.5)
     rexml (3.2.5)
     rubocop (1.36.0)
       json (~> 2.3)
@@ -56,9 +59,9 @@ PLATFORMS
 DEPENDENCIES
   awesome_print
   dead_end
+  debug
   minitest (~> 5.0)
   minitest-heat!
-  pry
   rake (~> 12.0)
   rubocop
   rubocop-minitest

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    minitest-heat (1.1.0)
+    minitest-heat (1.2.0)
       minitest
 
 GEM
@@ -55,6 +55,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  x86_64-linux
 
 DEPENDENCIES
   awesome_print

--- a/lib/minitest/heat/backtrace.rb
+++ b/lib/minitest/heat/backtrace.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require_relative 'backtrace/line_count'
 require_relative 'backtrace/line_parser'
 
 module Minitest

--- a/lib/minitest/heat/backtrace/line_count.rb
+++ b/lib/minitest/heat/backtrace/line_count.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Minitest
+  module Heat
+    class Backtrace
+      # Determines an optimal line count for backtrace locations in order to have relevant
+      #   information but keep the backtrace as compact as possible
+      class LineCount
+        DEFAULT_LINE_COUNT = 20
+
+        attr_accessor :locations
+
+        def initialize(locations)
+          @locations = locations
+        end
+
+        def earliest_project_location
+          locations.rindex { |element| element.project_file? }
+        end
+
+        def max_location
+          locations.size - 1
+        end
+
+        def limit
+          [
+            DEFAULT_LINE_COUNT,
+            earliest_project_location,
+            max_location
+          ].compact.min
+        end
+      end
+    end
+  end
+end

--- a/lib/minitest/heat/backtrace/line_parser.rb
+++ b/lib/minitest/heat/backtrace/line_parser.rb
@@ -11,7 +11,7 @@ module Minitest
         # Parses a line from a backtrace in order to convert it to usable components
         def self.read(raw_text)
           raw_pathname, raw_line_number, raw_container = raw_text.split(':')
-          raw_container = raw_container.delete_prefix('in `').delete_suffix("'")
+          raw_container = raw_container&.delete_prefix('in `')&.delete_suffix("'")
 
           ::Minitest::Heat::Location.new(
             pathname: raw_pathname,

--- a/lib/minitest/heat/issue.rb
+++ b/lib/minitest/heat/issue.rb
@@ -200,7 +200,13 @@ module Minitest
       #
       # @return [String] the first line of the exception message
       def first_line_of_exception_message
-        message.split("\n")[0]
+        text = message.split("\n")[0]
+
+        text.size > exception_message_limit ? "#{text[0..exception_message_limit]}..." : text
+      end
+
+      def exception_message_limit
+        200
       end
     end
   end

--- a/lib/minitest/heat/location.rb
+++ b/lib/minitest/heat/location.rb
@@ -147,7 +147,7 @@ module Minitest
       #   appear to be source code because the code is located in the project directory. This helps
       #   make sure the backtraces don't think that's the case
       #
-      # @return [Boolean] true if the file is in `<project_root>/vendor/bundle
+      # @return [Boolean] true if the file is in `<project_root>/bin
       def binstub_file?
         path.include?("#{project_root_dir}/bin")
       end

--- a/lib/minitest/heat/location.rb
+++ b/lib/minitest/heat/location.rb
@@ -133,7 +133,7 @@ module Minitest
       #
       # @return [Boolean] true if the file is in the project (source code or test) but not vendored
       def project_file?
-        path.include?(project_root_dir) && !bundled_file?
+        path.include?(project_root_dir) && !bundled_file? && !binstub_file?
       end
 
       # Determines if the file is in the project `vendor/bundle` directory.
@@ -141,6 +141,15 @@ module Minitest
       # @return [Boolean] true if the file is in `<project_root>/vendor/bundle
       def bundled_file?
         path.include?("#{project_root_dir}/vendor/bundle")
+      end
+
+      # Determines if the file is in the project `bin` directory. With binstub'd gems, they'll
+      #   appear to be source code because the code is located in the project directory. This helps
+      #   make sure the backtraces don't think that's the case
+      #
+      # @return [Boolean] true if the file is in `<project_root>/vendor/bundle
+      def binstub_file?
+        path.include?("#{project_root_dir}/bin")
       end
 
       # Determines if a given file follows the standard approaching to naming test files.
@@ -154,7 +163,7 @@ module Minitest
       #
       # @return [Boolean] true if the file is in the project but not a test file or vendored file
       def source_code_file?
-        project_file? && !test_file? && !bundled_file?
+        project_file? && !test_file?
       end
 
       # A safe interface to getting the last modified time for the file in question

--- a/lib/minitest/heat/output/backtrace.rb
+++ b/lib/minitest/heat/output/backtrace.rb
@@ -5,7 +5,6 @@ module Minitest
     class Output
       # Builds the collection of tokens for displaying a backtrace when an exception occurs
       class Backtrace
-        DEFAULT_LINE_COUNT = 10
         DEFAULT_INDENTATION_SPACES = 2
 
         attr_accessor :locations, :backtrace
@@ -25,14 +24,14 @@ module Minitest
         #
         # @return [Integer] the number of lines to limit the backtrace to
         def line_count
-          # Defined as a method instead of using the constant directlyr in order to easily support
+          # Defined as a method instead of using the constant directly in order to easily support
           # adding options for controlling how many lines are displayed from a backtrace.
           #
           # For example, instead of a fixed number, the backtrace could dynamically calculate how
           # many lines it should displaye in order to get to the origination point. Or it could have
           # a default, but inteligently go back further if the backtrace meets some criteria for
           # displaying more lines.
-          DEFAULT_LINE_COUNT
+          ::Minitest::Heat::Backtrace::LineCount.new(backtrace.locations).limit
         end
 
         # A subset of parsed lines from the backtrace.
@@ -49,7 +48,7 @@ module Minitest
           #   it could display the entire backtrace without filtering anything.
           # - It could scan the backtrace to the first appearance of project files and then display
           #   all of the lines that occurred after that instance
-          # - It coudl filter the lines differently whether the issue originated from a test or from
+          # - It could filter the lines differently whether the issue originated from a test or from
           #   the source code.
           # - It could allow supporting a "compact" or "robust" reporter style so that someone on
           #   a smaller screen could easily reduce the information shown so that the results could

--- a/lib/minitest/heat/version.rb
+++ b/lib/minitest/heat/version.rb
@@ -2,6 +2,6 @@
 
 module Minitest
   module Heat
-    VERSION = '1.1.0'
+    VERSION = '1.2.0'
   end
 end

--- a/minitest-heat.gemspec
+++ b/minitest-heat.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.description   = 'Presents test results in a visual manner to guide you to where to look first.'
   spec.homepage      = 'https://github.com/garrettdimon/minitest-heat'
   spec.license       = 'MIT'
-  spec.required_ruby_version = Gem::Requirement.new('>= 2.5.9')
+  spec.required_ruby_version = Gem::Requirement.new('>= 2.7.6')
 
   spec.metadata['homepage_uri'] = spec.homepage
   spec.metadata['bug_tracker_uri'] = 'https://github.com/garrettdimon/minitest-heat/issues'

--- a/minitest-heat.gemspec
+++ b/minitest-heat.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'awesome_print'
   spec.add_development_dependency 'dead_end'
-  spec.add_development_dependency 'pry'
+  spec.add_development_dependency 'debug'
   spec.add_development_dependency 'rubocop'
   spec.add_development_dependency 'rubocop-minitest'
   spec.add_development_dependency 'rubocop-rake'

--- a/test/minitest/contrived_code.rb
+++ b/test/minitest/contrived_code.rb
@@ -16,5 +16,17 @@ module Minitest
     def self.raise_another_example_error
       Issue.raise_another_example_error_from_issue
     end
+
+    def self.increase_the_stack_level
+      increase_the_stack_level_more
+    end
+
+    def self.increase_the_stack_level_more
+      increase_the_stack_level_even_more
+    end
+
+    def self.increase_the_stack_level_even_more
+      increase_the_stack_level
+    end
   end
 end

--- a/test/minitest/contrived_examples_test.rb
+++ b/test/minitest/contrived_examples_test.rb
@@ -83,6 +83,10 @@ class Minitest::ContrivedExamplesTest < Minitest::Test
       end
     end
 
+    def test_does_better_with_deep_stack_levels
+      ::Minitest::Heat.increase_the_stack_level
+    end
+
     def test_fails_after
       now = Time.now
       fail_after(now.year, now.month, now.day, 'This should explicitly fail because today is after the date')

--- a/test/minitest/contrived_heat_map_test.rb
+++ b/test/minitest/contrived_heat_map_test.rb
@@ -51,7 +51,7 @@ if ENV['FORCE_FAILURES'] || ENV['IMPLODE']
 
     def raise_error_indirectly
       # Both tests should end up here and thus have duplicate entries in the heat map
-      raise StandardError, 'Here is an indirectly raise exception'
+      raise StandardError, 'Here is an indirectly-raised exception'
     end
   end
 end

--- a/test/minitest/heat/backtrace/line_count_test.rb
+++ b/test/minitest/heat/backtrace/line_count_test.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class Minitest::Heat::Backtrace::LineCountTest < Minitest::Test
+  def setup
+    @test_location = ["#{Dir.pwd}/test/minitest/heat_test.rb", 23]
+    @raw_backtrace = [
+      "#{Dir.pwd}/lib/minitest/heat.rb:29:in `method_name'",
+      "#{Dir.pwd}/test/minitest/heat_test.rb:27:in `other_method_name'",
+      "#{Gem.dir}/gems/minitest-5.14.4/lib/minitest/test.rb:98:in `block (3 levels) in run'",
+      "#{Gem.dir}/gems/minitest-5.14.4/lib/minitest/test.rb:195:in `capture_exceptions'",
+      "#{Gem.dir}/gems/minitest-5.14.4/lib/minitest/test.rb:95:in `block (2 levels) in run'",
+      "#{Dir.pwd}/lib/minitest/heat.rb:29:in `method_name'",
+      "#{Dir.pwd}/test/minitest/heat_test.rb:27:in `other_method_name'",
+      "#{Gem.dir}/gems/minitest-5.14.4/lib/minitest/test.rb:98:in `block (3 levels) in run'",
+      "#{Gem.dir}/gems/minitest-5.14.4/lib/minitest/test.rb:195:in `capture_exceptions'",
+      "#{Gem.dir}/gems/minitest-5.14.4/lib/minitest/test.rb:95:in `block (2 levels) in run'",
+      "/file.rb:123: in `block'",
+      "/file.rb:123: in `block'",
+      "/file.rb:123: in `block'"
+    ]
+
+    @locations = Minitest::Heat::Locations.new(@test_location, @raw_backtrace)
+    @line_count = ::Minitest::Heat::Backtrace::LineCount.new(@locations.backtrace.locations)
+  end
+
+  def test_earliest_project_location
+    assert_equal 6, @line_count.earliest_project_location
+  end
+
+  def test_max_location
+    assert_equal 12, @line_count.max_location
+  end
+
+  def test_uses_earliest_project_location_if_present
+    assert_equal 6, @line_count.limit
+  end
+
+  def test_uses_default_line_count_if_lots_of_non_project_locations
+    @raw_backtrace = []
+    25.times do
+      @raw_backtrace << "/file.rb:123: in `block'"
+    end
+
+    @locations = Minitest::Heat::Locations.new(@test_location, @raw_backtrace)
+    @line_count = ::Minitest::Heat::Backtrace::LineCount.new(@locations.backtrace.locations)
+
+    assert_equal 20, @line_count.limit
+  end
+
+  def test_uses_max_if_no_project_files_and_not_enough_for_default
+    @raw_backtrace = []
+    5.times do
+      @raw_backtrace << "/file.rb:123: in `block'"
+    end
+
+    @locations = Minitest::Heat::Locations.new(@test_location, @raw_backtrace)
+    @line_count = ::Minitest::Heat::Backtrace::LineCount.new(@locations.backtrace.locations)
+
+    assert_equal @line_count.max_location, @line_count.limit
+  end
+end

--- a/test/minitest/heat/location_test.rb
+++ b/test/minitest/heat/location_test.rb
@@ -101,7 +101,30 @@ class Minitest::Heat::LocationTest < Minitest::Test
     FileUtils.touch(pathname)
 
     @location.raw_pathname = pathname
+    refute @location.binstub_file?
     assert @location.bundled_file?
+    refute @location.source_code_file?
+    refute @location.project_file?
+
+    # Get rid of the manually-created file and directory
+    FileUtils.rm_rf(directory)
+  end
+
+  def test_knows_if_binstub_file
+    # Root path is not a project file and should be recognized as one
+    @location.raw_pathname = '/'
+    refute @location.bundled_file?
+
+    # Manually create a file in vendor/bundle
+    directory = "#{Dir.pwd}/bin"
+    filename = "stub"
+    pathname = "#{directory}/#{filename}"
+    FileUtils.mkdir_p(directory)
+    FileUtils.touch(pathname)
+
+    @location.raw_pathname = pathname
+    assert @location.binstub_file?
+    refute @location.bundled_file?
     refute @location.source_code_file?
     refute @location.project_file?
 

--- a/test/minitest/heat/location_test.rb
+++ b/test/minitest/heat/location_test.rb
@@ -129,6 +129,6 @@ class Minitest::Heat::LocationTest < Minitest::Test
     refute @location.project_file?
 
     # Get rid of the manually-created file and directory
-    FileUtils.rm_rf(directory)
+    FileUtils.rm_rf(pathname)
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -25,7 +25,7 @@ if ENV['COVERAGE']
   end
 end
 
-require 'pry'
+require 'debug'
 
 $LOAD_PATH.unshift File.expand_path('../lib', __dir__)
 


### PR DESCRIPTION
Mainly some improvements to make test failures more resilient and improve the formatting when there are issues.

 - Don't consider binstubs project files when colorizing the stacktrace.
 - Switch debugging from Pry to debug
 - Ensure overly-long exception messages are truncated to reduce excessive scrolling
 - Make backtrace display smarter about how many lines to display
 - Fix bug that was incorrectly deleting the bin directory
 - Prepare for better handling of "stack level too deep" traces